### PR TITLE
Use DropCreateDatabaseIfModelChanges for DbInitializer

### DIFF
--- a/AspNetIdentity2ExtensibleTemplate/App_Start/IdentityConfig.cs
+++ b/AspNetIdentity2ExtensibleTemplate/App_Start/IdentityConfig.cs
@@ -104,7 +104,7 @@ namespace IdentitySample.Models
     // This is useful if you do not want to tear down the database each time you run the application.
     // public class ApplicationDbInitializer : DropCreateDatabaseAlways<ApplicationDbContext>
     // This example shows you how to create a new database if the Model changes
-    public class ApplicationDbInitializer : DropCreateDatabaseAlways<ApplicationDbContext> 
+    public class ApplicationDbInitializer : DropCreateDatabaseIfModelChanges<ApplicationDbContext> 
     {
         protected override void Seed(ApplicationDbContext context) {
             InitializeIdentityForEF(context);


### PR DESCRIPTION
Based on the comment, I think you meant to use DropCreateDatabaseIfModelChanges rather than DropCreateDatabaseAlways.
